### PR TITLE
refactor: Migrate data models from Parcelable to Serializable

### DIFF
--- a/app/src/main/java/com/example/bettinggame/RaceResultsActivity.java
+++ b/app/src/main/java/com/example/bettinggame/RaceResultsActivity.java
@@ -44,12 +44,11 @@ public class RaceResultsActivity extends AppCompatActivity {
         Button buttonNewGame = findViewById(R.id.buttonNewGame);
         Button buttonQuit = findViewById(R.id.buttonQuit);
 
-        // Nhận danh sách raceResultsList từ Intent
+        // Nhận danh sách raceResultsList từ Intent bằng Serializable
         if (getIntent().hasExtra("raceResults")) {
-            raceResultsList = getIntent().getParcelableArrayListExtra("raceResults", RaceResult.class);
+            raceResultsList = (ArrayList<RaceResult>) getIntent().getSerializableExtra("raceResults", ArrayList.class);
         }
 
-        // Fallback nếu không có dữ liệu nào được truyền hoặc lỗi xảy ra
         if (raceResultsList == null) {
             createSampleData();
         }
@@ -67,7 +66,6 @@ public class RaceResultsActivity extends AppCompatActivity {
                 AudioManagerUnified.playButtonSound(RaceResultsActivity.this);
                 Intent intent = new Intent(RaceResultsActivity.this, MainActivity.class);
                 intent.putExtra("username", playerName);
-                // Bỏ flags để không clear stack và giữ music state
                 startActivity(intent);
                 finish();
             }
@@ -82,7 +80,6 @@ public class RaceResultsActivity extends AppCompatActivity {
         });
     }
 
-    // Phương thức tạo dữ liệu mẫu (chỉ dùng làm fallback hoặc cho testing ban đầu)
     private void createSampleData() {
         raceResultsList = new ArrayList<>();
         raceResultsList.add(new RaceResult(new Duck("Vịt Donald Mẫu"), 2, -50.0));

--- a/app/src/main/java/com/example/bettinggame/model/Duck.java
+++ b/app/src/main/java/com/example/bettinggame/model/Duck.java
@@ -1,43 +1,13 @@
 package com.example.bettinggame.model;
 
-import android.os.Parcel;
-import android.os.Parcelable;
+import java.io.Serializable;
 
-public class Duck implements Parcelable {    private String name;
-    // private int waddleSpeed;
-    // private double quackLoudness;
+public class Duck implements Serializable {
+
+    private String name;
 
     public Duck(String name) {
         this.name = name;
-    }
-
-    protected Duck(Parcel in) {
-        name = in.readString();
-    }
-
-    public static final Creator<Duck> CREATOR = new Creator<Duck>() {
-        @Override
-        public Duck createFromParcel(Parcel in) {
-            return new Duck(in);
-        }
-
-        @Override
-        public Duck[] newArray(int size) {
-            return new Duck[size];
-        }
-    };
-
-    @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        dest.writeString(name); // Write the name to the Parcel
-        // If you add other fields, write them here in the same order as you read them:
-        // dest.writeInt(waddleSpeed);
-        // dest.writeDouble(quackLoudness);
     }
 
     // --- Getters and Setters ---
@@ -49,16 +19,10 @@ public class Duck implements Parcelable {    private String name;
         this.name = name;
     }
 
-    // Add getters and setters for any other fields you might add later
-
     @Override
     public String toString() {
-        // Đổi trong toString (Keeping your original comment)
         return "Duck{" +
                 "name='" + name + '\'' +
-                // If you add other fields, include them in toString() for easier debugging
-                // ", waddleSpeed=" + waddleSpeed +
-                // ", quackLoudness=" + quackLoudness +
                 '}';
     }
 }

--- a/app/src/main/java/com/example/bettinggame/model/RaceResult.java
+++ b/app/src/main/java/com/example/bettinggame/model/RaceResult.java
@@ -1,21 +1,23 @@
 package com.example.bettinggame.model;
 
-import android.os.Parcel;
-import android.os.Parcelable;
+import java.io.Serializable;
 
-public class RaceResult implements Parcelable {
+public class RaceResult implements Serializable {
+
     private Duck duck;
     private int rank;
     private double amountWon;
-    private transient int progress;
+    private int progress;
 
     // Constructor
     public RaceResult(Duck duck, int rank, double amountWon) {
         this.duck = duck;
         this.rank = rank;
         this.amountWon = amountWon;
+        this.progress = 0;
     }
 
+    // --- Getters and Setters ---
     public Duck getDuck() {
         return duck;
     }
@@ -47,36 +49,6 @@ public class RaceResult implements Parcelable {
     public void setProgress(int progress) {
         this.progress = progress;
     }
-
-    protected RaceResult(Parcel in) {
-        duck = in.readParcelable(Duck.class.getClassLoader());
-        rank = in.readInt();
-        amountWon = in.readDouble();
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        dest.writeParcelable(duck, flags);
-        dest.writeInt(rank);
-        dest.writeDouble(amountWon);
-    }
-
-    @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    public static final Creator<RaceResult> CREATOR = new Creator<RaceResult>() {
-        @Override
-        public RaceResult createFromParcel(Parcel in) {
-            return new RaceResult(in);
-        }
-
-        @Override
-        public RaceResult[] newArray(int size) {
-            return new RaceResult[size];
-        }
-    };
 
     @Override
     public String toString() {

--- a/app/src/main/java/com/example/bettinggame/model/TutorialStep.java
+++ b/app/src/main/java/com/example/bettinggame/model/TutorialStep.java
@@ -1,8 +1,8 @@
 package com.example.bettinggame.model;
 
 public class TutorialStep {
-    private int imageResId; // ID của ảnh drawable placeholder
-    private String description; // Nội dung hướng dẫn
+    private int imageResId;
+    private String description;
 
     public TutorialStep(int imageResId, String description) {
         this.imageResId = imageResId;

--- a/app/src/main/java/com/example/bettinggame/services/RaceManager.java
+++ b/app/src/main/java/com/example/bettinggame/services/RaceManager.java
@@ -25,6 +25,7 @@ import com.example.bettinggame.services.AudioManagerUnified;
 import pl.droidsonroids.gif.GifDrawable;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -313,7 +314,8 @@ public class RaceManager {
         Intent intent = new Intent(activity, RaceResultsActivity.class);
         if (activity instanceof MainActivity) {
             intent.putExtra("username", playerName);
-            intent.putParcelableArrayListExtra("raceResults", new ArrayList<>(results));
+            // Do RaceResult đã là Serializable, ta dùng putExtra cho cả ArrayList
+            intent.putExtra("raceResults", new ArrayList<Serializable>(results));
         }
         activity.startActivity(intent);
     }


### PR DESCRIPTION
This commit refactors the `Duck` and `RaceResult` data models to use the `Serializable` interface instead of `Parcelable` for passing data between activities.

Key changes include:
-   `Duck` and `RaceResult` now implement `Serializable`.
-   All `Parcelable` implementation code (CREATOR, `writeToParcel`, `describeContents`) has been removed.
-   `RaceResultsActivity` is updated to retrieve the `raceResults` list using `getSerializableExtra`.
-   `RaceManager` is updated to pass the results list as a `Serializable` extra.
-   The `transient` keyword is removed from the `progress` field in `RaceResult` to ensure it's included in serialization.